### PR TITLE
use elixir_auth_google v1.3.0 with latest httpoison 1.7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 elixir:
   - 1.10
 otp_release:
-  - 23
+  - 23.0
 addons: # ensure that Travis-CI provisions a DB for our test:
   postgresql: '9.5'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.9
+  - 1.10
 otp_release:
-  - 22.1.8
+  - 23
 addons: # ensure that Travis-CI provisions a DB for our test:
   postgresql: '9.5'
 env:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Open your `mix.exs` file and add the following line to your `deps` list:
 ```elixir
 def deps do
   [
-    {:elixir_auth_google, "~> 1.0.2"}
+    {:elixir_auth_google, "~> 1.3.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule App.MixProject do
       {:plug_cowboy, "~> 2.3.0"},
 
       # https://github.com/dwyl/elixir-auth-google
-      {:elixir_auth_google, "~> 1.2.0"}
+      {:elixir_auth_google, "~> 1.3.0"}
     ]
   end
 


### PR DESCRIPTION
+ [x] Demo app now uses `elixir_auth_google v1.3.0` with latest `httpoison@1.7`
see: https://github.com/dwyl/elixir-auth-google/issues/38

@iteles definitely not urgent. thanks for merging when you do. 👍 