### PR TITLE
Downgrade OTP version in `elixir_buildpack.config` to 23.3.2 fixes #8

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -3,7 +3,7 @@ elixir_version=1.12.3
 
 # Erlang version
 # available versions https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=24.0
+erlang_version=23.3.2
 
 # https://hexdocs.pm/phoenix/heroku.html#compilation-error
 always_rebuild=true


### PR DESCRIPTION
as the title suggests, this PR downgrades the version of OTP `elixir_buildpack.config` for #8 
